### PR TITLE
add probeBusGated patch

### DIFF
--- a/EFI/OC/config.plist
+++ b/EFI/OC/config.plist
@@ -205,7 +205,7 @@
 				<key>layout-id</key>
 				<integer>11</integer>
 			</dict>
-			<key>#PciRoot(0x0)/Pci(0x1,0x1)/Pci(0x0,0x0)/Pci(0x0,0x0)/Pci(0x0,0x0)</key>
+			<key>PciRoot(0x0)/Pci(0x1,0x1)/Pci(0x0,0x0)/Pci(0x0,0x0)/Pci(0x0,0x0)</key>
 			<dict>
 				<key>device-id</key>
 				<data>/3MAAA==</data>
@@ -931,6 +931,36 @@
 				<string>17.0.0</string>
 				<key>Replace</key>
 				<data>JfwAAAAPHwA=</data>
+				<key>ReplaceMask</key>
+				<data></data>
+				<key>Skip</key>
+				<integer>0</integer>
+			</dict>
+			<dict>
+				<key>Arch</key>
+				<string>x86_64</string>
+				<key>Base</key>
+				<string>__ZN11IOPCIBridge13probeBusGatedEP14probeBusParams</string>
+				<key>Comment</key>
+				<string>CaseySJ - probeBusGated Disable 10 bit tags - 12.0/13.0</string>
+				<key>Count</key>
+				<integer>1</integer>
+				<key>Enabled</key>
+				<true/>
+				<key>Find</key>
+				<data>5hFyBg==</data>
+				<key>Identifier</key>
+				<string>com.apple.iokit.IOPCIFamily</string>
+				<key>Limit</key>
+				<integer>0</integer>
+				<key>Mask</key>
+				<data></data>
+				<key>MaxKernel</key>
+				<string>22.99.99</string>
+				<key>MinKernel</key>
+				<string>21.0.0</string>
+				<key>Replace</key>
+				<data>5hFzBg==</data>
 				<key>ReplaceMask</key>
 				<data></data>
 				<key>Skip</key>

--- a/IOPCIFamily.md
+++ b/IOPCIFamily.md
@@ -1,4 +1,7 @@
 # Replacing IOPCIFamily.kext
+
+**NOTE : This workaround is no longer required after applying the [probeBusGated patch](https://github.com/AMD-OSX/AMD_Vanilla/compare/f0cf7827578216047325220784a469c77e8e7b98...3be0cb6c4a6651e8dde9026c6de637473eac24d6) ( d0fce4d ).**
+
 ## Problems
 macOS Monterey has many problems with GA402 because vanilla IOPCIFamily.kext is not working well.
 - Random boot failure

--- a/IOPCIFamily.md
+++ b/IOPCIFamily.md
@@ -1,6 +1,6 @@
 # Replacing IOPCIFamily.kext
 
-**NOTE : This workaround is no longer required after applying the [probeBusGated patch](https://github.com/AMD-OSX/AMD_Vanilla/compare/f0cf7827578216047325220784a469c77e8e7b98...3be0cb6c4a6651e8dde9026c6de637473eac24d6) ( d0fce4d ).**
+**NOTE : This workaround is no longer required after applying the [probeBusGated patch](https://github.com/AMD-OSX/AMD_Vanilla/compare/f0cf7827578216047325220784a469c77e8e7b98...3be0cb6c4a6651e8dde9026c6de637473eac24d6) ( [d0fce4d](https://github.com/b00t0x/ROG-Zephyrus-G14-GA402-Hackintosh/commit/d0fce4deb7d7cb807e3494c9577be4e505800fbb) ).**
 
 ## Problems
 macOS Monterey has many problems with GA402 because vanilla IOPCIFamily.kext is not working well.

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Currently not all functions and components work properly ( especially trackpad )
 - WiFi : Intel AX210 WiFi 6 ( replaced from original MediaTek M.2 2230 card )
 
 ### Software
-- macOS Monterey 12.4 (21F79)
-- OpenCore 0.8.1
+- macOS Monterey 12.6.1 (21G217)
+- OpenCore 0.8.3
 
 ## Current status
 ### Working
@@ -41,6 +41,9 @@ Currently not all functions and components work properly ( especially trackpad )
 - Integrated camera
 
 ### Not working / Problems
+- BIOS version 315
+  - The system became very unstable after updating to BIOS 315, I have to stay on BIOS 312.
+  - The `length` of APIC.aml patch changed.
 - Radeon 680 iGPU
   - Probably never works, that's why I bought the laptop with dGPU.
   - Left USB-C DP alt doesn't work because of it's controlled by iGPU.
@@ -57,9 +60,7 @@ Currently not all functions and components work properly ( especially trackpad )
   - Only sound hotkeys work
 - macOS Ventura beta
   - Stuck at `ACPI: sleep states` even if using OpenCore nightly.
-- Vanilla IOPCIFamily.kext / AppleACPIPlatform.kext
-  - Must be replaced with Big Sur's one.
-  - Without replacing, PCIe gen mixed SSD / WiFi not working.
+  - Installer works, but first boot after install fails.
 - Longer battery life
   - Even in dGPU mode, Windows should run for 3 hours but it only runs for around an hour and a half in macOS.
   - In iGPU mode, Windows should run for 10 hours, but iGPU doesn't work in macOS.
@@ -75,7 +76,6 @@ Deleting original APIC.aml also required.
 In spite of the laptop doesn't have TRX40 chipset, DevirtualiseMmio quirk is required to avoid stuck on `[EB|#LOG:EXITBS:START]`. MmioWhitelist is also required to avoid blackout issue.
 
 #### dGPU DeviceProperties
-These properties are commented out because of not working before replacing IOPCIFamily.kext. To enable this, read [IOPCIFamily.md](IOPCIFamily.md).
 
 - `device-id` : `FF730000`
   - spoofed as RX 6600 series.


### PR DESCRIPTION
Big Sur kexts replacement is no longer required after applying the [probeBusGated patch](https://github.com/AMD-OSX/AMD_Vanilla/compare/f0cf7827578216047325220784a469c77e8e7b98...3be0cb6c4a6651e8dde9026c6de637473eac24d6)